### PR TITLE
refactor: move /v1 prefix from base URL onto each endpoint path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.7.2] - 2026-05-13
+
+### Changed
+- Moved `/v1` prefix from the base URL constant (`CB_PRIME_BASE_URL`) onto each service implementation path, so the base URL is now `https://api.prime.coinbase.com` without a trailing version segment; all request URIs are unchanged
+
 ## [1.7.1] - 2026-04-21
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <description>Sample Java SDK for the Coinbase Prime REST APIs</description>
   <groupId>com.coinbase.prime</groupId>
   <url>https://github.com/coinbase-samples/prime-sdk-java</url>
-  <version>1.7.1</version>
+  <version>1.7.2</version>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>

--- a/src/main/java/com/coinbase/prime/activities/ActivitiesServiceImpl.java
+++ b/src/main/java/com/coinbase/prime/activities/ActivitiesServiceImpl.java
@@ -35,7 +35,7 @@ public class ActivitiesServiceImpl extends CoinbaseServiceImpl implements Activi
             throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/activities", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/activities", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<ListPortfolioActivitiesResponse>() {});
@@ -45,7 +45,7 @@ public class ActivitiesServiceImpl extends CoinbaseServiceImpl implements Activi
     public GetActivityResponse getActivity(GetActivityRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/activities/%s", request.getActivityId()),
+                String.format("/v1/activities/%s", request.getActivityId()),
                 request,
                 List.of(200),
                 new TypeReference<GetActivityResponse>() {});
@@ -56,7 +56,7 @@ public class ActivitiesServiceImpl extends CoinbaseServiceImpl implements Activi
             throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/activities", request.getEntityId()),
+                String.format("/v1/entities/%s/activities", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<ListEntityActivitiesResponse>() {});
@@ -67,7 +67,7 @@ public class ActivitiesServiceImpl extends CoinbaseServiceImpl implements Activi
             throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/activities/%s", request.getPortfolioId(), request.getActivityId()),
+                String.format("/v1/portfolios/%s/activities/%s", request.getPortfolioId(), request.getActivityId()),
                 request,
                 List.of(200),
                 new TypeReference<GetPortfolioActivityResponse>() {});

--- a/src/main/java/com/coinbase/prime/addressbook/AddressBookServiceImpl.java
+++ b/src/main/java/com/coinbase/prime/addressbook/AddressBookServiceImpl.java
@@ -33,7 +33,7 @@ public class AddressBookServiceImpl extends CoinbaseServiceImpl implements Addre
     public ListAddressBookResponse listAddressBook(ListAddressBookRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/address_book", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/address_book", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<ListAddressBookResponse>() {});
@@ -43,7 +43,7 @@ public class AddressBookServiceImpl extends CoinbaseServiceImpl implements Addre
     public CreateAddressBookEntryResponse createAddressBookEntry(CreateAddressBookEntryRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/address_book", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/address_book", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<CreateAddressBookEntryResponse>() {});

--- a/src/main/java/com/coinbase/prime/advancedtransfers/AdvancedTransfersServiceImpl.java
+++ b/src/main/java/com/coinbase/prime/advancedtransfers/AdvancedTransfersServiceImpl.java
@@ -34,7 +34,7 @@ public class AdvancedTransfersServiceImpl extends CoinbaseServiceImpl implements
     public ListAdvancedTransfersResponse listAdvancedTransfers(ListAdvancedTransfersRequest request) throws CoinbaseClientException, CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/advanced_transfers", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/advanced_transfers", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<ListAdvancedTransfersResponse>() {});
@@ -44,7 +44,7 @@ public class AdvancedTransfersServiceImpl extends CoinbaseServiceImpl implements
     public CreateAdvancedTransferResponse createAdvancedTransfer(CreateAdvancedTransferRequest request) throws CoinbaseClientException, CoinbasePrimeException {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/advanced_transfers", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/advanced_transfers", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<CreateAdvancedTransferResponse>() {});
@@ -54,7 +54,7 @@ public class AdvancedTransfersServiceImpl extends CoinbaseServiceImpl implements
     public CancelAdvancedTransferResponse cancelAdvancedTransfer(CancelAdvancedTransferRequest request) throws CoinbaseClientException, CoinbasePrimeException {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/advanced_transfers/%s/cancel", request.getPortfolioId(), request.getAdvancedTransferId()),
+                String.format("/v1/portfolios/%s/advanced_transfers/%s/cancel", request.getPortfolioId(), request.getAdvancedTransferId()),
                 request,
                 List.of(200),
                 new TypeReference<CancelAdvancedTransferResponse>() {});

--- a/src/main/java/com/coinbase/prime/allocations/AllocationsServiceImpl.java
+++ b/src/main/java/com/coinbase/prime/allocations/AllocationsServiceImpl.java
@@ -34,7 +34,7 @@ public class AllocationsServiceImpl extends CoinbaseServiceImpl implements Alloc
     public CreateAllocationResponse createAllocation(CreateAllocationRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.POST,
-                "/allocations",
+                "/v1/allocations",
                 request,
                 List.of(200),
                 new TypeReference<CreateAllocationResponse>() {});
@@ -44,7 +44,7 @@ public class AllocationsServiceImpl extends CoinbaseServiceImpl implements Alloc
     public CreateNetAllocationResponse createNetAllocation(CreateNetAllocationRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.POST,
-                "/allocations/net",
+                "/v1/allocations/net",
                 request,
                 List.of(200),
                 new TypeReference<CreateNetAllocationResponse>() {});
@@ -54,7 +54,7 @@ public class AllocationsServiceImpl extends CoinbaseServiceImpl implements Alloc
     public ListPortfolioAllocationsResponse getPortfolioAllocations(ListPortfolioAllocationsRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/allocations", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/allocations", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<ListPortfolioAllocationsResponse>() {});
@@ -64,7 +64,7 @@ public class AllocationsServiceImpl extends CoinbaseServiceImpl implements Alloc
     public GetAllocationResponse getAllocation(GetAllocationRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/allocations/%s", request.getPortfolioId(), request.getAllocationId()),
+                String.format("/v1/portfolios/%s/allocations/%s", request.getPortfolioId(), request.getAllocationId()),
                 null,
                 List.of(200),
                 new TypeReference<GetAllocationResponse>() {});
@@ -74,7 +74,7 @@ public class AllocationsServiceImpl extends CoinbaseServiceImpl implements Alloc
     public ListAllocationsByNettingIdResponse listAllocationsByNettingId(ListAllocationsByNettingIdRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/allocations/net/%s", request.getPortfolioId(), request.getNettingId()),
+                String.format("/v1/portfolios/%s/allocations/net/%s", request.getPortfolioId(), request.getNettingId()),
                 request,
                 List.of(200),
                 new TypeReference<ListAllocationsByNettingIdResponse>() {});

--- a/src/main/java/com/coinbase/prime/assets/AssetsServiceImpl.java
+++ b/src/main/java/com/coinbase/prime/assets/AssetsServiceImpl.java
@@ -34,7 +34,7 @@ public class AssetsServiceImpl extends CoinbaseServiceImpl implements AssetsServ
     public ListAssetsResponse listAssets(ListAssetsRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/assets", request.getEntityId()),
+                String.format("/v1/entities/%s/assets", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<ListAssetsResponse>() {});

--- a/src/main/java/com/coinbase/prime/balances/BalancesServiceImpl.java
+++ b/src/main/java/com/coinbase/prime/balances/BalancesServiceImpl.java
@@ -33,7 +33,7 @@ public class BalancesServiceImpl extends CoinbaseServiceImpl implements Balances
     public ListEntityBalancesResponse listEntityBalances(ListEntityBalancesRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/balances", request.getEntityId()),
+                String.format("/v1/entities/%s/balances", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<ListEntityBalancesResponse>() {});
@@ -43,7 +43,7 @@ public class BalancesServiceImpl extends CoinbaseServiceImpl implements Balances
     public ListPortfolioBalancesResponse listPortfolioBalances(ListPortfolioBalancesRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/balances", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/balances", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<ListPortfolioBalancesResponse>() {});
@@ -53,7 +53,7 @@ public class BalancesServiceImpl extends CoinbaseServiceImpl implements Balances
     public GetWalletBalanceResponse getWalletBalance(GetWalletBalanceRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/wallets/%s/balance", request.getPortfolioId(), request.getWalletId()),
+                String.format("/v1/portfolios/%s/wallets/%s/balance", request.getPortfolioId(), request.getWalletId()),
                 null,
                 List.of(200),
                 new TypeReference<GetWalletBalanceResponse>() {});
@@ -63,7 +63,7 @@ public class BalancesServiceImpl extends CoinbaseServiceImpl implements Balances
     public ListOnchainWalletBalancesResponse listOnchainWalletBalances(ListOnchainWalletBalancesRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/wallets/%s/web3_balances", request.getPortfolioId(), request.getWalletId()),
+                String.format("/v1/portfolios/%s/wallets/%s/web3_balances", request.getPortfolioId(), request.getWalletId()),
                 request,
                 List.of(200),
                 new TypeReference<ListOnchainWalletBalancesResponse>() {});

--- a/src/main/java/com/coinbase/prime/commission/CommissionServiceImpl.java
+++ b/src/main/java/com/coinbase/prime/commission/CommissionServiceImpl.java
@@ -33,7 +33,7 @@ public class CommissionServiceImpl extends CoinbaseServiceImpl implements Commis
     public GetPortfolioCommissionResponse getPortfolioCommission(GetPortfolioCommissionRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/commission", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/commission", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<GetPortfolioCommissionResponse>() {});

--- a/src/main/java/com/coinbase/prime/financing/FinancingServiceImpl.java
+++ b/src/main/java/com/coinbase/prime/financing/FinancingServiceImpl.java
@@ -33,7 +33,7 @@ public class FinancingServiceImpl extends CoinbaseServiceImpl implements Financi
     public CreateNewLocatesResponse createNewLocates(CreateNewLocatesRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/locates", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/locates", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<CreateNewLocatesResponse>() {});
@@ -43,7 +43,7 @@ public class FinancingServiceImpl extends CoinbaseServiceImpl implements Financi
     public GetCrossMarginOverviewResponse getCrossMarginOverview(GetCrossMarginOverviewRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/cross_margin", request.getEntityId()),
+                String.format("/v1/entities/%s/cross_margin", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<GetCrossMarginOverviewResponse>() {});
@@ -53,7 +53,7 @@ public class FinancingServiceImpl extends CoinbaseServiceImpl implements Financi
     public GetEntityLocateAvailabilitiesResponse getEntityLocateAvailabilities(GetEntityLocateAvailabilitiesRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/locates/locates_availability", request.getEntityId()),
+                String.format("/v1/entities/%s/locates/locates_availability", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<GetEntityLocateAvailabilitiesResponse>() {});
@@ -63,7 +63,7 @@ public class FinancingServiceImpl extends CoinbaseServiceImpl implements Financi
     public GetMarginInformationResponse getMarginInformation(GetMarginInformationRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/margin", request.getEntityId()),
+                String.format("/v1/entities/%s/margin", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<GetMarginInformationResponse>() {});
@@ -73,7 +73,7 @@ public class FinancingServiceImpl extends CoinbaseServiceImpl implements Financi
     public GetPortfolioBuyingPowerResponse getPortfolioBuyingPower(GetPortfolioBuyingPowerRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/buying_power", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/buying_power", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<GetPortfolioBuyingPowerResponse>() {});
@@ -83,7 +83,7 @@ public class FinancingServiceImpl extends CoinbaseServiceImpl implements Financi
     public GetPortfolioCreditInformationResponse getPortfolioCreditInformation(GetPortfolioCreditInformationRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/credit", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/credit", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<GetPortfolioCreditInformationResponse>() {});
@@ -93,7 +93,7 @@ public class FinancingServiceImpl extends CoinbaseServiceImpl implements Financi
     public GetPortfolioWithdrawalPowerResponse getPortfolioWithdrawalPower(GetPortfolioWithdrawalPowerRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/withdrawal_power", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/withdrawal_power", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<GetPortfolioWithdrawalPowerResponse>() {});
@@ -103,7 +103,7 @@ public class FinancingServiceImpl extends CoinbaseServiceImpl implements Financi
     public GetTradeFinanceTieredPricingFeesResponse getTradeFinanceTieredPricingFees(GetTradeFinanceTieredPricingFeesRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/tf_tiered_fees", request.getEntityId()),
+                String.format("/v1/entities/%s/tf_tiered_fees", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<GetTradeFinanceTieredPricingFeesResponse>() {});
@@ -113,7 +113,7 @@ public class FinancingServiceImpl extends CoinbaseServiceImpl implements Financi
     public ListExistingLocatesResponse listExistingLocates(ListExistingLocatesRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/locates", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/locates", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<ListExistingLocatesResponse>() {});
@@ -123,7 +123,7 @@ public class FinancingServiceImpl extends CoinbaseServiceImpl implements Financi
     public ListInterestAccrualsResponse listInterestAccruals(ListInterestAccrualsRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/accruals", request.getEntityId()),
+                String.format("/v1/entities/%s/accruals", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<ListInterestAccrualsResponse>() {});
@@ -133,7 +133,7 @@ public class FinancingServiceImpl extends CoinbaseServiceImpl implements Financi
     public ListInterestAccrualsForPortfolioResponse listInterestAccrualsForPortfolio(ListInterestAccrualsForPortfolioRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/accruals", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/accruals", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<ListInterestAccrualsForPortfolioResponse>() {});
@@ -143,7 +143,7 @@ public class FinancingServiceImpl extends CoinbaseServiceImpl implements Financi
     public ListMarginCallSummariesResponse listMarginCallSummaries(ListMarginCallSummariesRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/margin_summaries", request.getEntityId()),
+                String.format("/v1/entities/%s/margin_summaries", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<ListMarginCallSummariesResponse>() {});
@@ -153,7 +153,7 @@ public class FinancingServiceImpl extends CoinbaseServiceImpl implements Financi
     public ListMarginConversionsResponse listMarginConversions(ListMarginConversionsRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/margin_conversions", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/margin_conversions", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<ListMarginConversionsResponse>() {});
@@ -163,7 +163,7 @@ public class FinancingServiceImpl extends CoinbaseServiceImpl implements Financi
     public ListTfObligationsResponse listTfObligations(ListTfObligationsRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/tf_obligations", request.getEntityId()),
+                String.format("/v1/entities/%s/tf_obligations", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<ListTfObligationsResponse>() {});
@@ -173,7 +173,7 @@ public class FinancingServiceImpl extends CoinbaseServiceImpl implements Financi
     public ListFinancingEligibleAssetsResponse listFinancingEligibleAssets(ListFinancingEligibleAssetsRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                "/financing/eligible-assets",
+                "/v1/financing/eligible-assets",
                 request,
                 List.of(200),
                 new TypeReference<ListFinancingEligibleAssetsResponse>() {});

--- a/src/main/java/com/coinbase/prime/futures/FuturesServiceImpl.java
+++ b/src/main/java/com/coinbase/prime/futures/FuturesServiceImpl.java
@@ -33,7 +33,7 @@ public class FuturesServiceImpl extends CoinbaseServiceImpl implements FuturesSe
     public SetAutoSweepResponse setAutoSweep(SetAutoSweepRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.POST,
-                String.format("/entities/%s/futures/auto_sweep", request.getEntityId()),
+                String.format("/v1/entities/%s/futures/auto_sweep", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<SetAutoSweepResponse>() {});
@@ -43,7 +43,7 @@ public class FuturesServiceImpl extends CoinbaseServiceImpl implements FuturesSe
     public GetEntityFcmBalanceResponse getEntityFcmBalance(GetEntityFcmBalanceRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/futures/balance_summary", request.getEntityId()),
+                String.format("/v1/entities/%s/futures/balance_summary", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<GetEntityFcmBalanceResponse>() {});
@@ -54,7 +54,7 @@ public class FuturesServiceImpl extends CoinbaseServiceImpl implements FuturesSe
     public ListEntityFuturesSweepsResponse listEntityFuturesSweeps(ListEntityFuturesSweepsRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/futures/sweeps", request.getEntityId()),
+                String.format("/v1/entities/%s/futures/sweeps", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<ListEntityFuturesSweepsResponse>() {});
@@ -64,7 +64,7 @@ public class FuturesServiceImpl extends CoinbaseServiceImpl implements FuturesSe
     public CancelEntityFuturesSweepResponse cancelEntityFuturesSweep(CancelEntityFuturesSweepRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.DELETE,
-                String.format("/entities/%s/futures/sweeps", request.getEntityId()),
+                String.format("/v1/entities/%s/futures/sweeps", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<CancelEntityFuturesSweepResponse>() {});
@@ -74,7 +74,7 @@ public class FuturesServiceImpl extends CoinbaseServiceImpl implements FuturesSe
     public ScheduleEntityFuturesSweepResponse scheduleEntityFuturesSweep(ScheduleEntityFuturesSweepRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.POST,
-                String.format("/entities/%s/futures/sweeps", request.getEntityId()),
+                String.format("/v1/entities/%s/futures/sweeps", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<ScheduleEntityFuturesSweepResponse>() {});
@@ -84,7 +84,7 @@ public class FuturesServiceImpl extends CoinbaseServiceImpl implements FuturesSe
     public GetFcmMarginCallDetailsResponse getFcmMarginCallDetails(GetFcmMarginCallDetailsRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/futures/margin_call_details", request.getEntityId()),
+                String.format("/v1/entities/%s/futures/margin_call_details", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<GetFcmMarginCallDetailsResponse>() {});
@@ -94,7 +94,7 @@ public class FuturesServiceImpl extends CoinbaseServiceImpl implements FuturesSe
     public GetFcmRiskLimitsResponse getFcmRiskLimits(GetFcmRiskLimitsRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/futures/risk_limits", request.getEntityId()),
+                String.format("/v1/entities/%s/futures/risk_limits", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<GetFcmRiskLimitsResponse>() {});
@@ -104,7 +104,7 @@ public class FuturesServiceImpl extends CoinbaseServiceImpl implements FuturesSe
     public GetPositionsResponse getPositions(GetPositionsRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/futures/positions", request.getEntityId()),
+                String.format("/v1/entities/%s/futures/positions", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<GetPositionsResponse>() {});
@@ -114,7 +114,7 @@ public class FuturesServiceImpl extends CoinbaseServiceImpl implements FuturesSe
     public GetFcmSettingsResponse getFcmSettings(GetFcmSettingsRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/futures/settings", request.getEntityId()),
+                String.format("/v1/entities/%s/futures/settings", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<GetFcmSettingsResponse>() {});
@@ -124,7 +124,7 @@ public class FuturesServiceImpl extends CoinbaseServiceImpl implements FuturesSe
     public SetFcmSettingsResponse setFcmSettings(SetFcmSettingsRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.POST,
-                String.format("/entities/%s/futures/settings", request.getEntityId()),
+                String.format("/v1/entities/%s/futures/settings", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<SetFcmSettingsResponse>() {});
@@ -134,7 +134,7 @@ public class FuturesServiceImpl extends CoinbaseServiceImpl implements FuturesSe
     public GetFcmEquityResponse getFcmEquity(GetFcmEquityRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/futures/equity", request.getEntityId()),
+                String.format("/v1/entities/%s/futures/equity", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<GetFcmEquityResponse>() {});

--- a/src/main/java/com/coinbase/prime/invoice/InvoiceServiceImpl.java
+++ b/src/main/java/com/coinbase/prime/invoice/InvoiceServiceImpl.java
@@ -33,7 +33,7 @@ public class InvoiceServiceImpl extends CoinbaseServiceImpl implements InvoiceSe
     public ListInvoicesResponse listInvoices(ListInvoicesRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/invoices", request.getEntityId()),
+                String.format("/v1/entities/%s/invoices", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<ListInvoicesResponse>() {});

--- a/src/main/java/com/coinbase/prime/onchainaddressbook/OnchainAddressBookServiceImpl.java
+++ b/src/main/java/com/coinbase/prime/onchainaddressbook/OnchainAddressBookServiceImpl.java
@@ -31,7 +31,7 @@ public class OnchainAddressBookServiceImpl extends CoinbaseServiceImpl implement
     public CreateOnchainAddressBookEntryResponse createOnchainAddressBookEntry(CreateOnchainAddressBookEntryRequest request) {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/onchain_address_group", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/onchain_address_group", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<CreateOnchainAddressBookEntryResponse>() {});
@@ -40,7 +40,7 @@ public class OnchainAddressBookServiceImpl extends CoinbaseServiceImpl implement
     public UpdateOnchainAddressBookEntryResponse updateOnchainAddressBookEntry(UpdateOnchainAddressBookEntryRequest request) {
         return this.request(
                 HttpMethod.PUT,
-                String.format("/portfolios/%s/onchain_address_group", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/onchain_address_group", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<UpdateOnchainAddressBookEntryResponse>() {});
@@ -49,7 +49,7 @@ public class OnchainAddressBookServiceImpl extends CoinbaseServiceImpl implement
     public DeleteOnchainAddressGroupResponse deleteOnchainAddressGroup(DeleteOnchainAddressGroupRequest request) {
         return this.request(
                 HttpMethod.DELETE,
-                String.format("/portfolios/%s/onchain_address_group/%s", request.getPortfolioId(), request.getAddressGroupId()),
+                String.format("/v1/portfolios/%s/onchain_address_group/%s", request.getPortfolioId(), request.getAddressGroupId()),
                 request,
                 List.of(200),
                 new TypeReference<DeleteOnchainAddressGroupResponse>() {});
@@ -58,7 +58,7 @@ public class OnchainAddressBookServiceImpl extends CoinbaseServiceImpl implement
     public ListOnchainAddressGroupsResponse listOnchainAddressGroups(ListOnchainAddressGroupsRequest request) {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/onchain_address_groups", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/onchain_address_groups", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<ListOnchainAddressGroupsResponse>() {});

--- a/src/main/java/com/coinbase/prime/orders/OrdersServiceImpl.java
+++ b/src/main/java/com/coinbase/prime/orders/OrdersServiceImpl.java
@@ -33,7 +33,7 @@ public class OrdersServiceImpl extends CoinbaseServiceImpl implements OrdersServ
     public ListOpenOrdersResponse listOpenOrders(ListOpenOrdersRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/open_orders", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/open_orders", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<ListOpenOrdersResponse>() {});
@@ -43,7 +43,7 @@ public class OrdersServiceImpl extends CoinbaseServiceImpl implements OrdersServ
     public CreateOrderResponse createOrder(CreateOrderRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/order", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/order", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<CreateOrderResponse>() {});
@@ -53,7 +53,7 @@ public class OrdersServiceImpl extends CoinbaseServiceImpl implements OrdersServ
     public GetOrderPreviewResponse getOrderPreview(GetOrderPreviewRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/order_preview", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/order_preview", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<GetOrderPreviewResponse>() {});
@@ -64,7 +64,7 @@ public class OrdersServiceImpl extends CoinbaseServiceImpl implements OrdersServ
             throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/orders", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/orders", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<ListPortfolioOrdersResponse>() {});
@@ -74,7 +74,7 @@ public class OrdersServiceImpl extends CoinbaseServiceImpl implements OrdersServ
     public GetOrderByOrderIdResponse getOrderByOrderId(GetOrderByOrderIdRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/orders/%s", request.getPortfolioId(), request.getOrderId()),
+                String.format("/v1/portfolios/%s/orders/%s", request.getPortfolioId(), request.getOrderId()),
                 request,
                 List.of(200),
                 new TypeReference<GetOrderByOrderIdResponse>() {});
@@ -84,7 +84,7 @@ public class OrdersServiceImpl extends CoinbaseServiceImpl implements OrdersServ
     public CancelOrderResponse cancelOrder(CancelOrderRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/orders/%s/cancel", request.getPortfolioId(), request.getOrderId()),
+                String.format("/v1/portfolios/%s/orders/%s/cancel", request.getPortfolioId(), request.getOrderId()),
                 request,
                 List.of(200),
                 new TypeReference<CancelOrderResponse>() {});
@@ -94,7 +94,7 @@ public class OrdersServiceImpl extends CoinbaseServiceImpl implements OrdersServ
     public ListOrderFillsResponse listOrderFills(ListOrderFillsRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/orders/%s/fills", request.getPortfolioId(), request.getOrderId()),
+                String.format("/v1/portfolios/%s/orders/%s/fills", request.getPortfolioId(), request.getOrderId()),
                 request,
                 List.of(200),
                 new TypeReference<ListOrderFillsResponse>() {});
@@ -105,7 +105,7 @@ public class OrdersServiceImpl extends CoinbaseServiceImpl implements OrdersServ
             throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/fills", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/fills", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<ListPortfolioFillsResponse>() {});
@@ -115,7 +115,7 @@ public class OrdersServiceImpl extends CoinbaseServiceImpl implements OrdersServ
     public CreateQuoteResponse createQuote(CreateQuoteRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/rfq", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/rfq", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<CreateQuoteResponse>() {});
@@ -125,7 +125,7 @@ public class OrdersServiceImpl extends CoinbaseServiceImpl implements OrdersServ
     public AcceptQuoteResponse acceptQuote(AcceptQuoteRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/accept_quote", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/accept_quote", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<AcceptQuoteResponse>() {});
@@ -136,7 +136,7 @@ public class OrdersServiceImpl extends CoinbaseServiceImpl implements OrdersServ
             throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/orders/%s/edit_history", request.getPortfolioId(), request.getOrderId()),
+                String.format("/v1/portfolios/%s/orders/%s/edit_history", request.getPortfolioId(), request.getOrderId()),
                 request,
                 List.of(200),
                 new TypeReference<ListOrderEditHistoryResponse>() {});
@@ -146,7 +146,7 @@ public class OrdersServiceImpl extends CoinbaseServiceImpl implements OrdersServ
     public EditOrderResponse editOrder(EditOrderRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.PUT,
-                String.format("/portfolios/%s/orders/%s/edit", request.getPortfolioId(), request.getOrderId()),
+                String.format("/v1/portfolios/%s/orders/%s/edit", request.getPortfolioId(), request.getOrderId()),
                 request,
                 List.of(200),
                 new TypeReference<EditOrderResponse>() {});

--- a/src/main/java/com/coinbase/prime/paymentmethods/PaymentMethodsServiceImpl.java
+++ b/src/main/java/com/coinbase/prime/paymentmethods/PaymentMethodsServiceImpl.java
@@ -33,7 +33,7 @@ public class PaymentMethodsServiceImpl extends CoinbaseServiceImpl implements Pa
     public ListPaymentMethodsResponse listPaymentMethods(ListPaymentMethodsRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/payment-methods", request.getEntityId()),
+                String.format("/v1/entities/%s/payment-methods", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<ListPaymentMethodsResponse>() {});
@@ -43,7 +43,7 @@ public class PaymentMethodsServiceImpl extends CoinbaseServiceImpl implements Pa
     public GetPaymentMethodDetailsResponse getPaymentMethodDetails(GetPaymentMethodDetailsRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/payment-methods/%s", request.getEntityId(), request.getPaymentMethodId()),
+                String.format("/v1/entities/%s/payment-methods/%s", request.getEntityId(), request.getPaymentMethodId()),
                 null,
                 List.of(200),
                 new TypeReference<GetPaymentMethodDetailsResponse>() {});

--- a/src/main/java/com/coinbase/prime/portfolios/PortfoliosServiceImpl.java
+++ b/src/main/java/com/coinbase/prime/portfolios/PortfoliosServiceImpl.java
@@ -33,7 +33,7 @@ public class PortfoliosServiceImpl extends CoinbaseServiceImpl implements Portfo
     public ListPortfoliosResponse listPortfolios(ListPortfoliosRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                "/portfolios",
+                "/v1/portfolios",
                 request,
                 List.of(200),
                 new TypeReference<ListPortfoliosResponse>() {});
@@ -43,7 +43,7 @@ public class PortfoliosServiceImpl extends CoinbaseServiceImpl implements Portfo
     public GetPortfolioResponse getPortfolio(GetPortfolioRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s", request.getPortfolioId()),
                 null,
                 List.of(200),
                 new TypeReference<GetPortfolioResponse>() {});
@@ -54,7 +54,7 @@ public class PortfoliosServiceImpl extends CoinbaseServiceImpl implements Portfo
             throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/counterparty", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/counterparty", request.getPortfolioId()),
                 null,
                 List.of(200),
                 new TypeReference<GetPortfolioCounterpartyIdResponse>() {});

--- a/src/main/java/com/coinbase/prime/positions/PositionsServiceImpl.java
+++ b/src/main/java/com/coinbase/prime/positions/PositionsServiceImpl.java
@@ -32,7 +32,7 @@ public class PositionsServiceImpl extends CoinbaseServiceImpl implements Positio
     public ListAggregatePositionsResponse listAggregatePositions(ListAggregatePositionsRequest request) {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/aggregate_positions", request.getId()),
+                String.format("/v1/entities/%s/aggregate_positions", request.getId()),
                 request,
                 List.of(200),
                 new TypeReference<ListAggregatePositionsResponse>() {});
@@ -42,7 +42,7 @@ public class PositionsServiceImpl extends CoinbaseServiceImpl implements Positio
     public ListPositionsResponse listPositions(ListPositionsRequest request) {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/positions", request.getId()),
+                String.format("/v1/entities/%s/positions", request.getId()),
                 request,
                 List.of(200),
                 new TypeReference<ListPositionsResponse>() {});

--- a/src/main/java/com/coinbase/prime/products/ProductsServiceImpl.java
+++ b/src/main/java/com/coinbase/prime/products/ProductsServiceImpl.java
@@ -33,7 +33,7 @@ public class ProductsServiceImpl extends CoinbaseServiceImpl implements Products
     public ListCandlesResponse listCandles(ListCandlesRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/candles", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/candles", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<ListCandlesResponse>() {});
@@ -43,7 +43,7 @@ public class ProductsServiceImpl extends CoinbaseServiceImpl implements Products
     public ListPortfolioProductsResponse listPortfolioProducts(ListPortfolioProductsRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/products", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/products", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<ListPortfolioProductsResponse>() {});

--- a/src/main/java/com/coinbase/prime/staking/StakingServiceImpl.java
+++ b/src/main/java/com/coinbase/prime/staking/StakingServiceImpl.java
@@ -32,7 +32,7 @@ public class StakingServiceImpl extends CoinbaseServiceImpl implements StakingSe
     public CreateStakeResponse createStake(CreateStakeRequest request) {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/wallets/%s/staking/initiate", request.getPortfolioId(), request.getWalletId()),
+                String.format("/v1/portfolios/%s/wallets/%s/staking/initiate", request.getPortfolioId(), request.getWalletId()),
                 request,
                 List.of(200),
                 new TypeReference<CreateStakeResponse>() {});
@@ -42,7 +42,7 @@ public class StakingServiceImpl extends CoinbaseServiceImpl implements StakingSe
     public CreateUnstakeResponse createUnstake(CreateUnstakeRequest request) {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/wallets/%s/staking/unstake", request.getPortfolioId(), request.getWalletId()),
+                String.format("/v1/portfolios/%s/wallets/%s/staking/unstake", request.getPortfolioId(), request.getWalletId()),
                 request,
                 List.of(200),
                 new TypeReference<CreateUnstakeResponse>() {});
@@ -52,7 +52,7 @@ public class StakingServiceImpl extends CoinbaseServiceImpl implements StakingSe
     public ListTransactionValidatorsResponse listTransactionValidators(ListTransactionValidatorsRequest request) {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/staking/transaction-validators/query", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/staking/transaction-validators/query", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<ListTransactionValidatorsResponse>() {});
@@ -62,7 +62,7 @@ public class StakingServiceImpl extends CoinbaseServiceImpl implements StakingSe
     public PortfolioStakingInitiateResponse portfolioStakingInitiate(PortfolioStakingInitiateRequest request) {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/staking/initiate", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/staking/initiate", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<PortfolioStakingInitiateResponse>() {});
@@ -72,7 +72,7 @@ public class StakingServiceImpl extends CoinbaseServiceImpl implements StakingSe
     public PortfolioStakingUnstakeResponse portfolioStakingUnstake(PortfolioStakingUnstakeRequest request) {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/staking/unstake", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/staking/unstake", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<PortfolioStakingUnstakeResponse>() {});
@@ -82,7 +82,7 @@ public class StakingServiceImpl extends CoinbaseServiceImpl implements StakingSe
     public ClaimRewardsResponse claimRewards(ClaimRewardsRequest request) {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/wallets/%s/staking/claim_rewards", request.getPortfolioId(), request.getWalletId()),
+                String.format("/v1/portfolios/%s/wallets/%s/staking/claim_rewards", request.getPortfolioId(), request.getWalletId()),
                 request,
                 List.of(200),
                 new TypeReference<ClaimRewardsResponse>() {});
@@ -92,7 +92,7 @@ public class StakingServiceImpl extends CoinbaseServiceImpl implements StakingSe
     public PreviewUnstakeResponse previewUnstake(PreviewUnstakeRequest request) {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/wallets/%s/staking/unstake/preview", request.getPortfolioId(), request.getWalletId()),
+                String.format("/v1/portfolios/%s/wallets/%s/staking/unstake/preview", request.getPortfolioId(), request.getWalletId()),
                 request,
                 List.of(200),
                 new TypeReference<PreviewUnstakeResponse>() {});
@@ -102,7 +102,7 @@ public class StakingServiceImpl extends CoinbaseServiceImpl implements StakingSe
     public GetUnstakingStatusResponse getUnstakingStatus(GetUnstakingStatusRequest request) {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/wallets/%s/staking/unstake/status", request.getPortfolioId(), request.getWalletId()),
+                String.format("/v1/portfolios/%s/wallets/%s/staking/unstake/status", request.getPortfolioId(), request.getWalletId()),
                 request,
                 List.of(200),
                 new TypeReference<GetUnstakingStatusResponse>() {});
@@ -112,7 +112,7 @@ public class StakingServiceImpl extends CoinbaseServiceImpl implements StakingSe
     public GetStakingStatusResponse getStakingStatus(GetStakingStatusRequest request) {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/wallets/%s/staking/status", request.getPortfolioId(), request.getWalletId()),
+                String.format("/v1/portfolios/%s/wallets/%s/staking/status", request.getPortfolioId(), request.getWalletId()),
                 request,
                 List.of(200),
                 new TypeReference<GetStakingStatusResponse>() {});

--- a/src/main/java/com/coinbase/prime/transactions/TransactionsServiceImpl.java
+++ b/src/main/java/com/coinbase/prime/transactions/TransactionsServiceImpl.java
@@ -33,7 +33,7 @@ public class TransactionsServiceImpl extends CoinbaseServiceImpl implements Tran
     public GetTransactionResponse getTransaction(GetTransactionRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/transactions/%s", request.getPortfolioId(), request.getTransactionId()),
+                String.format("/v1/portfolios/%s/transactions/%s", request.getPortfolioId(), request.getTransactionId()),
                 request,
                 List.of(200),
                 new TypeReference<GetTransactionResponse>() {});
@@ -43,7 +43,7 @@ public class TransactionsServiceImpl extends CoinbaseServiceImpl implements Tran
     public CreateConversionResponse createConversion(CreateConversionRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/wallets/%s/conversion", request.getPortfolioId(), request.getWalletId()),
+                String.format("/v1/portfolios/%s/wallets/%s/conversion", request.getPortfolioId(), request.getWalletId()),
                 request,
                 List.of(200),
                 new TypeReference<CreateConversionResponse>() {});
@@ -54,7 +54,7 @@ public class TransactionsServiceImpl extends CoinbaseServiceImpl implements Tran
             throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/transactions", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/transactions", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<ListPortfolioTransactionsResponse>() {});
@@ -65,7 +65,7 @@ public class TransactionsServiceImpl extends CoinbaseServiceImpl implements Tran
             throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/wallets/%s/transactions", request.getPortfolioId(),
+                String.format("/v1/portfolios/%s/wallets/%s/transactions", request.getPortfolioId(),
                         request.getWalletId()),
                 request,
                 List.of(200),
@@ -77,7 +77,7 @@ public class TransactionsServiceImpl extends CoinbaseServiceImpl implements Tran
             throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/wallets/%s/transfers", request.getPortfolioId(), request.getWalletId()),
+                String.format("/v1/portfolios/%s/wallets/%s/transfers", request.getPortfolioId(), request.getWalletId()),
                 request,
                 List.of(200),
                 new TypeReference<CreateWalletTransferResponse>() {});
@@ -88,7 +88,7 @@ public class TransactionsServiceImpl extends CoinbaseServiceImpl implements Tran
             throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/wallets/%s/withdrawals", request.getPortfolioId(), request.getWalletId()),
+                String.format("/v1/portfolios/%s/wallets/%s/withdrawals", request.getPortfolioId(), request.getWalletId()),
                 request,
                 List.of(200),
                 new TypeReference<CreateWalletWithdrawalResponse>() {});
@@ -99,7 +99,7 @@ public class TransactionsServiceImpl extends CoinbaseServiceImpl implements Tran
             throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/wallets/%s/onchain_transaction", request.getPortfolioId(),
+                String.format("/v1/portfolios/%s/wallets/%s/onchain_transaction", request.getPortfolioId(),
                         request.getWalletId()),
                 request,
                 List.of(200),
@@ -111,7 +111,7 @@ public class TransactionsServiceImpl extends CoinbaseServiceImpl implements Tran
             throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/advanced_transfers/%s/transactions", request.getPortfolioId(),
+                String.format("/v1/portfolios/%s/advanced_transfers/%s/transactions", request.getPortfolioId(),
                         request.getAdvancedTransferId()),
                 request,
                 List.of(200),
@@ -128,7 +128,7 @@ public class TransactionsServiceImpl extends CoinbaseServiceImpl implements Tran
             throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/transactions/%s/travel_rule/deposit", request.getPortfolioId(),
+                String.format("/v1/portfolios/%s/transactions/%s/travel_rule/deposit", request.getPortfolioId(),
                         request.getTransactionId()),
                 request,
                 List.of(200),
@@ -140,7 +140,7 @@ public class TransactionsServiceImpl extends CoinbaseServiceImpl implements Tran
             throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/transactions/%s/travel_rule", request.getPortfolioId(),
+                String.format("/v1/portfolios/%s/transactions/%s/travel_rule", request.getPortfolioId(),
                         request.getTransactionId()),
                 request,
                 List.of(200),

--- a/src/main/java/com/coinbase/prime/users/UsersServiceImpl.java
+++ b/src/main/java/com/coinbase/prime/users/UsersServiceImpl.java
@@ -33,7 +33,7 @@ public class UsersServiceImpl extends CoinbaseServiceImpl implements UsersServic
     public ListEntityUsersResponse listEntityUsers(ListEntityUsersRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/entities/%s/users", request.getEntityId()),
+                String.format("/v1/entities/%s/users", request.getEntityId()),
                 request,
                 List.of(200),
                 new TypeReference<ListEntityUsersResponse>() {});
@@ -43,7 +43,7 @@ public class UsersServiceImpl extends CoinbaseServiceImpl implements UsersServic
     public ListPortfolioUsersResponse listPortfolioUsers(ListPortfolioUsersRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/users", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/users", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<ListPortfolioUsersResponse>() {});

--- a/src/main/java/com/coinbase/prime/utils/Constants.java
+++ b/src/main/java/com/coinbase/prime/utils/Constants.java
@@ -22,6 +22,6 @@ public class Constants {
     public static final String CB_ACCESS_SIGNATURE_HEADER = "X-CB-ACCESS-SIGNATURE";
     public static final String CB_ACCESS_TIMESTAMP_HEADER = "X-CB-ACCESS-TIMESTAMP";
     public static final String CB_USER_AGENT_HEADER = "User-Agent";
-    public static final String CB_PRIME_BASE_URL = "https://api.prime.coinbase.com/v1";
+    public static final String CB_PRIME_BASE_URL = "https://api.prime.coinbase.com";
     public static final String SDK_VERSION = "1.4.0";
 }

--- a/src/main/java/com/coinbase/prime/wallets/WalletsServiceImpl.java
+++ b/src/main/java/com/coinbase/prime/wallets/WalletsServiceImpl.java
@@ -33,7 +33,7 @@ public class WalletsServiceImpl extends CoinbaseServiceImpl implements WalletsSe
     public ListWalletsResponse listWallets(ListWalletsRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/wallets", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/wallets", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<ListWalletsResponse>() {});
@@ -43,7 +43,7 @@ public class WalletsServiceImpl extends CoinbaseServiceImpl implements WalletsSe
     public CreateWalletResponse createWallet(CreateWalletRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/wallets", request.getPortfolioId()),
+                String.format("/v1/portfolios/%s/wallets", request.getPortfolioId()),
                 request,
                 List.of(200),
                 new TypeReference<CreateWalletResponse>() {});
@@ -53,7 +53,7 @@ public class WalletsServiceImpl extends CoinbaseServiceImpl implements WalletsSe
     public GetWalletResponse getWallet(GetWalletRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/wallets/%s", request.getPortfolioId(), request.getWalletId()),
+                String.format("/v1/portfolios/%s/wallets/%s", request.getPortfolioId(), request.getWalletId()),
                 request,
                 List.of(200),
                 new TypeReference<GetWalletResponse>() {});
@@ -64,7 +64,7 @@ public class WalletsServiceImpl extends CoinbaseServiceImpl implements WalletsSe
             GetWalletDepositInstructionsRequest request) throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/wallets/%s/deposit_instructions", request.getPortfolioId(),
+                String.format("/v1/portfolios/%s/wallets/%s/deposit_instructions", request.getPortfolioId(),
                         request.getWalletId()),
                 request,
                 List.of(200),
@@ -76,7 +76,7 @@ public class WalletsServiceImpl extends CoinbaseServiceImpl implements WalletsSe
             throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.GET,
-                String.format("/portfolios/%s/wallets/%s/addresses", request.getPortfolioId(), request.getWalletId()),
+                String.format("/v1/portfolios/%s/wallets/%s/addresses", request.getPortfolioId(), request.getWalletId()),
                 request,
                 List.of(200),
                 new TypeReference<ListWalletAddressesResponse>() {});
@@ -87,7 +87,7 @@ public class WalletsServiceImpl extends CoinbaseServiceImpl implements WalletsSe
             throws CoinbasePrimeException {
         return this.request(
                 HttpMethod.POST,
-                String.format("/portfolios/%s/wallets/%s/addresses", request.getPortfolioId(), request.getWalletId()),
+                String.format("/v1/portfolios/%s/wallets/%s/addresses", request.getPortfolioId(), request.getWalletId()),
                 request,
                 List.of(200),
                 new TypeReference<CreateWalletDepositAddressResponse>() {});


### PR DESCRIPTION
Strip `/v1` from `CB_PRIME_BASE_URL` so the base URL is `https://api.prime.coinbase.com`. Prefix every service impl path with `/v1` (or `/v2` where applicable) so the full request URI is unchanged.

This allows the SDK to support versioned paths (e.g. `/v2/...` beta endpoints) without requiring callers to initialize a separate client with a different base URL.

Made with [Cursor](https://cursor.com)