### PR TITLE
chore: use blockquote deprecation notice in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Coinbase Prime Java SDK
 
-The canonical source repository is **[coinbase/prime-sdk-java](https://github.com/coinbase/prime-sdk-java)**. The former [coinbase-samples/prime-sdk-java](https://github.com/coinbase-samples/prime-sdk-java) repository is deprecated. Maven Central releases **1.9.0+** are published from the canonical repository.
+> **Deprecated:** This repository has moved to [github.com/coinbase/prime-sdk-java](https://github.com/coinbase/prime-sdk-java).
+> Install from Maven Central with group `com.coinbase.prime` and artifact `coinbase-prime-sdk-java`. The coordinates are unchanged; releases **1.9.0+** are published from the canonical repository.
+> This repository is no longer maintained.
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.coinbase.prime/coinbase-prime-sdk-java.svg)](https://central.sonatype.com/artifact/com.coinbase.prime/coinbase-prime-sdk-java)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)


### PR DESCRIPTION
## Summary

Reformat the README deprecation notice as a blockquote banner at the top of the file, matching the format adopted across the other Prime SDK samples repos (see coinbase-samples/prime-sdk-dotnet#24). Points users to the canonical [coinbase/prime-sdk-java](https://github.com/coinbase/prime-sdk-java) repository, notes the Maven coordinates are unchanged, and states the repo is no longer maintained.

## Testing

Documentation-only change; no build or test impact.

## Notes

No version bump, tag, or Maven Central publish from samples.

Change management: type=routine risk=low impact=sev5